### PR TITLE
Fix payment amount

### DIFF
--- a/upload/catalog/controller/extension/payment/paypro.php
+++ b/upload/catalog/controller/extension/payment/paypro.php
@@ -59,7 +59,7 @@ abstract class ControllerExtensionPaymentPayPro extends Controller {
 			$redirectUrl = html_entity_decode($this->url->link($this->path . '/payment_redirect', '&order_id=' . $orderId, true));
 
 			$paymentData = [
-				'amount' => round($amount, 2) * 100,
+				'amount' => (int) (round($amount * 100, 0)),
 				'pay_method' => $this->getPaymentMethod(),
 				'return_url' => $redirectUrl,
 				'cancel_url' => $redirectUrl,


### PR DESCRIPTION
We receive the error: amount `1998.9999999999998` is not a valid integer, the amount is not rounded correctly.

Same issues we have:
paypronl/prestashop-payments-plugin#2
paypronl/magento2-payments-plugin#5
https://github.com/paypronl/edd-payments-plugin/pull/5